### PR TITLE
Adds link to privacy policy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ source "https://rubygems.org"
 gem 'jekyll-redirect-from'
 gem "jekyll"
 gem "html-proofer"
+gem "kramdown-parser-gfm"
 gemspec

--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ theme_settings:
   header_text:
   header_text_feature_image:
   footer_text: >
-   Powered by <a href="https://jekyllrb.com/" style="text-decoration:underline">Jekyll</a> with <a href="https://github.com/rohanchandra/type-theme" style="text-decoration:underline">Type Theme</a>
+   Powered by <a href="https://jekyllrb.com/">Jekyll</a> with <a href="https://github.com/rohanchandra/type-theme">Type Theme</a>
 
   # Icons
   rss: false

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,6 +5,7 @@
 {% if site.theme_settings.footer_text %}
 <footer>
 	<div class="site-footer">
+	<p class="text"><a href="https://rockarch.org/about-us/privacy-policy/" style="text-decoration:underline">RAC Privacy Policy</a></p>
 	<p class="text">{{ site.theme_settings.footer_text }}</p>
 	</div>
 	<div class="license-footer">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,9 @@
 {% if site.theme_settings.footer_text %}
 <footer>
 	<div class="site-footer">
-	<p class="text"><a href="https://rockarch.org/about-us/privacy-policy/" style="text-decoration:underline">RAC Privacy Policy</a></p>
+	<p class="text">
+		<a rel="RAC Privacy Policy" href="https://rockarch.org/about-us/privacy-policy/" style="text-decoration:underline">RAC Privacy Policy</a>
+	</p>
 	<p class="text">{{ site.theme_settings.footer_text }}</p>
 	</div>
 	<div class="license-footer">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,9 +5,7 @@
 {% if site.theme_settings.footer_text %}
 <footer>
 	<div class="site-footer">
-	<p class="text">
-		<a rel="RAC Privacy Policy" href="https://rockarch.org/about-us/privacy-policy/" style="text-decoration:underline">RAC Privacy Policy</a>
-	</p>
+	<a href="https://rockarch.org/about-us/privacy-policy/">Privacy Policy</a>
 	<p class="text">{{ site.theme_settings.footer_text }}</p>
 	</div>
 	<div class="license-footer">

--- a/_sass/includes/_footer.scss
+++ b/_sass/includes/_footer.scss
@@ -5,6 +5,9 @@
   float: left;
   color: lighten($text-color, 10%);
   font-size: 0.9em;
+  a {
+    text-decoration: underline;
+  }
 }
 .license-footer{
   float: right;

--- a/jekyll-theme-type.gemspec
+++ b/jekyll-theme-type.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll", "~> 3.4"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
 
-  spec.add_development_dependency "bundler", "~> 2.0.1"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
Adds link to RAC privacy policy. Fixes #100 . Keeping it extremely simple right now. Just adds it over the theme's footer text.

<img width="1440" alt="Screen Shot 2020-08-12 at 11 24 02 AM" src="https://user-images.githubusercontent.com/2585069/90034415-97e42700-dc8e-11ea-814b-e67f25d03519.png">
