### PR TITLE
Disambiguate posts with the same title

### DIFF
--- a/_posts/2019-09-19-what-were-working-on.md
+++ b/_posts/2019-09-19-what-were-working-on.md
@@ -1,5 +1,6 @@
 ---
 title: "What We're Working On"
+permalink: /what-were-working-on-2019-09
 date: 2019-09-17T14:00:00+00:00
 author: Hillel Arnold
 layout: post

--- a/_posts/2021-10-12-what-were-working-on.md
+++ b/_posts/2021-10-12-what-were-working-on.md
@@ -1,5 +1,6 @@
 ---
 title: What We're Working On
+permalink: /what-were-working-on-2021-10
 date: 2021-10-12T09:00:00
 author: Hillel Arnold
 layout: post

--- a/_posts/2022-04-29-what-were-working-on.md
+++ b/_posts/2022-04-29-what-were-working-on.md
@@ -1,5 +1,6 @@
 ---
 title: "What We're Working On"
+permalink: /what-were-working-on-2022-04
 date: 2022-04-29T09:00:00
 author: Hillel Arnold
 layout: post

--- a/_posts/2022-05-20-using-graylog-to-better-understand-our-systems.md
+++ b/_posts/2022-05-20-using-graylog-to-better-understand-our-systems.md
@@ -9,7 +9,7 @@ tags:
   - infrastructure
 excerpt_separator: <!--more-->
 ---
-As Hillel mentioned in the most recent ["What We're Working On" post](https://blog.rockarch.org/what-were-working-on), the RAC has recently implemented a log management system called [Graylog](https://www.graylog.org/). Making better use of our log files and improving our system reliability and response time was a core goal of [becoming better maintainers](https://blog.rockarch.org/becoming-better-maintainers) and operationalizing our systems work. We built logging into almost all of our locally-developed systems and had experience sifting through ArchivesSpace logs, but we weren't actively using them as indicators of application health or issues.
+As Hillel mentioned in the most recent ["What We're Working On" post](https://blog.rockarch.org/what-were-working-on-2022-04), the RAC has recently implemented a log management system called [Graylog](https://www.graylog.org/). Making better use of our log files and improving our system reliability and response time was a core goal of [becoming better maintainers](https://blog.rockarch.org/becoming-better-maintainers) and operationalizing our systems work. We built logging into almost all of our locally-developed systems and had experience sifting through ArchivesSpace logs, but we weren't actively using them as indicators of application health or issues.
 
 <!--more-->
 


### PR DESCRIPTION
Adds a `permalink` field to the front matter to disambiguate posts with the same title. I did this rather than change the permalink scheme globally (in `_config.yml`) since that would break all of the site links.

Fixes #161 